### PR TITLE
Add google ops agent config [Finishes #184448773]

### DIFF
--- a/config/ops-agent/config.yaml
+++ b/config/ops-agent/config.yaml
@@ -21,6 +21,11 @@ logging:
       - /apps/spidamin/logs/spida/*[0-9]*
       - /apps/spidamin/logs/spida/*performance*
       record_log_file_path: true
+    Tomcat:
+      type: files
+      include_paths: 
+      - /apps/spidamin/logs/tomcat/catalina.out
+      record_log_file_path: true
     Spida_Studio_Perf:
       type: files
       include_paths:

--- a/config/ops-agent/config.yaml
+++ b/config/ops-agent/config.yaml
@@ -57,4 +57,3 @@ logging:
     pipelines:
       default_pipeline:
         receivers: [Spida_Studio, Spida_Studio_Perf, Mongo, Suricata, ClamAV, Audit]
-        

--- a/config/ops-agent/google-ops-agent.conf
+++ b/config/ops-agent/google-ops-agent.conf
@@ -1,0 +1,60 @@
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# <== Enter custom agent configurations in this file.
+# See https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration
+# for more details.
+
+logging:
+  receivers:
+    Spida_Studio:
+      type: files
+      include_paths:
+      - /apps/spidamin/logs/spida/*.log
+      exclude_paths:
+      - /apps/spidamin/logs/spida/*[0-9]*
+      - /apps/spidamin/logs/spida/*performance*
+      record_log_file_path: true
+    Spida_Studio_Perf:
+      type: files
+      include_paths:
+      - /apps/spidamin/logs/spida/*performance*
+      exclude_paths:
+      - /apps/spidamin/logs/spida/*[0-9]*
+      record_log_file_path: true
+    Mongo:
+      type: files
+      include_paths:
+      - /apps/spidamin/logs/mongodb
+      exclude_paths:
+      - /apps/spidamin/logs/spida/*[0-9]*
+      record_log_file_path: true
+    Suricata:
+      type: files
+      include_paths:
+      - /var/log/suricata/suricata.log
+      - /var/log/suricata/eve.json
+      - /var/log/suricata/stats.log
+      - /var/log/suricata/fast.log
+      record_log_file_path: true
+    ClamAV:
+      type: files
+      include_paths:
+      - /var/log/clamav/clamav.log
+      record_log_file_path: true
+    Audit:
+      type: files
+      include_paths:
+      - /var/log/audit/audit.log
+      record_log_file_path: true
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [Spida_Studio, Spida_Studio_Perf, Mongo, Suricata, ClamAV, Audit]
+        

--- a/install
+++ b/install
@@ -155,9 +155,34 @@ waitForService() {
 #
 ####################################################################################
 function installDocker() {
-  curl -sSL https://get.docker.com/ | sh
-  curl -L https://github.com/docker/compose/releases/download/1.7.0/docker-compose-`uname -s`-`uname -m` > /usr/bin/docker-compose
-  chmod +x /usr/bin/docker-compose
+  #Steps Copied From https://docs.docker.com/engine/install/ubuntu/
+
+  # Setup apt repository and keyring
+  # Step 1
+  sudo apt-get update
+  sudo apt-get install \
+      ca-certificates \
+      curl \
+      gnupg
+
+  # Step 2
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+  # Step 3
+  echo \
+    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+  # Install Docker Client
+  # Step 1
+  sudo apt-get update
+
+  # Step 2 (Installs Latest Docker Version Available to the Repo w/ compatible compose)
+  sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+
   if [[ -f "/etc/redhat-release" ]]; then
     sudo mkdir /etc/systemd/system/docker.service.d
     sudo touch /etc/systemd/system/docker.service.d/docker.conf


### PR DESCRIPTION
Removes the docker convenience script installer and replaces it with the commands suggested in the docker documentation for production instances.

https://docs.docker.com/engine/install/ubuntu/

Also , adds the configuration file Ops-Agent logging configuration.