### PR TITLE
"docker-compose" instead of "docker-compose-plugin" [Delivers #184448773]

### DIFF
--- a/config/ops-agent/config.yaml
+++ b/config/ops-agent/config.yaml
@@ -61,4 +61,4 @@ logging:
   service:
     pipelines:
       default_pipeline:
-        receivers: [Spida_Studio, Spida_Studio_Perf, Mongo, Suricata, ClamAV, Audit]
+        receivers: [Spida_Studio, Spida_Studio_Perf, Mongo, Suricata, ClamAV, Audit, Tomcat]

--- a/install
+++ b/install
@@ -181,7 +181,7 @@ function installDocker() {
   sudo apt-get update
 
   # Step 2 (Installs Latest Docker Version Available to the Repo w/ compatible compose)
-  sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+  sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose -y
 
   if [[ -f "/etc/redhat-release" ]]; then
     sudo mkdir /etc/systemd/system/docker.service.d


### PR DESCRIPTION
docker-compose-plugin installs the newer "docker compose" based on GO , we are unable to use that version currently